### PR TITLE
ODROID-GO: BATTERY

### DIFF
--- a/src/odroid_go.cpp
+++ b/src/odroid_go.cpp
@@ -30,6 +30,9 @@ void ODROID_GO::begin() {
     lcd.setTextSize(1);
     lcd.setBrightness(255);
 
+    // Battery
+    battery.begin();
+
     Serial.println("OK");
 }
 
@@ -47,5 +50,6 @@ void ODROID_GO::update() {
 
     //Speaker update
     Speaker.update();
+    battery.update();
 }
 ODROID_GO GO;

--- a/src/odroid_go.h
+++ b/src/odroid_go.h
@@ -12,6 +12,7 @@
 #include "utility/music_8bit.h"
 #include "utility/Button.h"
 #include "utility/bmp_map.h"
+#include "utility/battery.h"
 
 extern "C" {
 #include "esp_sleep.h"
@@ -36,6 +37,7 @@ class ODROID_GO {
     // LCD
     ILI9341 lcd = ILI9341();
     SPEAKER Speaker;
+    Battery battery;
 
 
 };

--- a/src/utility/battery.cpp
+++ b/src/utility/battery.cpp
@@ -1,0 +1,57 @@
+/*
+ * battery.cpp
+ *
+ *  Created on: 5 de jul de 2018
+ *      Author: mdrjr
+ */
+
+#include "battery.h"
+
+Battery::Battery() {
+	this->_enable_protection = false;
+}
+
+void Battery::begin() {
+	adc1_config_width(ADC_WIDTH_BIT_12);
+	adc1_config_channel_atten(ADC1_CHANNEL_0, ADC_ATTEN_DB_11);
+	esp_adc_cal_characterize(ADC_UNIT_1, ADC_ATTEN_DB_11, ADC_WIDTH_BIT_12, ESP_ADC_CAL_VAL_EFUSE_TP, &_adc_chars);
+}
+
+double Battery::getVoltage() {
+	uint32_t adc_reading = 0;
+
+	for (int i = 0; i < BATTERY_SAMPLES; i++) {
+		adc_reading += adc1_get_raw((adc1_channel_t) ADC1_CHANNEL_0);
+	}
+
+	adc_reading /= BATTERY_SAMPLES;
+
+	return (double) esp_adc_cal_raw_to_voltage(adc_reading, &_adc_chars) * BATTERY_RESISTANCE_NUM / 1000;
+}
+
+int Battery::getPercentage() {
+
+	int res = 101 - (101 / pow(1 + pow(1.33 * ((int)(getVoltage() * 100) - BATTERY_VMIN)/(BATTERY_VMAX - BATTERY_VMIN), 4.5), 3));
+
+	if(res >= 100)
+		res = 100;
+
+	return res;
+}
+
+void Battery::setProtection(bool enable) {
+	this->_enable_protection = enable;
+}
+
+void Battery::update() {
+	if(this->_enable_protection == true) {
+		int curr_voltage = (int)(getVoltage() * 100);
+
+		if(curr_voltage <= BATTERY_CUTOFF) {
+			esp_deep_sleep(30 * 60 * 1000000);
+			esp_deep_sleep_start();
+		}
+
+	}
+}
+

--- a/src/utility/battery.h
+++ b/src/utility/battery.h
@@ -1,0 +1,38 @@
+/*
+ * battery.h
+ *
+ *  Created on: 5 de jul de 2018
+ *      Author: mdrjr
+ */
+
+#ifndef LIBRARIES_ODROID_GO_SRC_UTILITY_BATTERY_H_
+#define LIBRARIES_ODROID_GO_SRC_UTILITY_BATTERY_H_
+
+#include "Arduino.h"
+#include "Config.h"
+#include <driver/adc.h>
+#include <esp_adc_cal.h>
+
+#define BATTERY_RESISTANCE_NUM 2
+#define BATTERY_SAMPLES 64
+#define BATTERY_VMAX 420
+#define BATTERY_VMIN 330
+#define BATTERY_CUTOFF 325
+
+class Battery {
+public:
+	Battery(void);
+
+	void begin();
+	double getVoltage();
+	int getPercentage();
+	void setProtection(bool enable);
+	void update();
+
+private:
+	esp_adc_cal_characteristics_t _adc_chars;
+	bool _enable_protection;
+};
+
+#endif /* LIBRARIES_ODROID_GO_SRC_UTILITY_BATTERY_H_ */
+


### PR DESCRIPTION
This commit introduces the Battery as a class.
It's safe to assume that battery is present since its part of the product.

It adds:

GO.batt.getVoltage(): returns a double with the current battery voltage sampled 64 times
GO.batt.getgetPercentage(): returns a integer with the actual percentage of the battery, calculated from 3.3 to 4.2V