### PR TITLE
ESP-IDF 3.2 and arduino-esp32 compatibility

### DIFF
--- a/component.mk
+++ b/component.mk
@@ -5,5 +5,7 @@
 
 #COMPONENT_SRCDIRS := . src
 #COMPONENT_ADD_INCLUDEDIRS := . src
-COMPONENT_SRCDIRS := src
-COMPONENT_ADD_INCLUDEDIRS := src
+
+COMPONENT_SRCDIRS := src src/utility src/sensors src/sensors/ir src/web src/web/libb64 src/web/detail src/web/libsha1 src/Fonts src/Fonts/GFXFF src/Fonts/Custom src/Fonts/TrueType
+COMPONENT_ADD_INCLUDEDIRS := src src/utility src/sensors src/sensors/ir src/web src/web/libb64 src/web/detail src/web/libsha1 src/Fonts src/Fonts/GFXFF src/Fonts/Custom src/Fonts/TrueType
+

--- a/src/sensors/RTClib.cpp
+++ b/src/sensors/RTClib.cpp
@@ -153,7 +153,7 @@ DateTime::DateTime (const char* date, const char* time) {
 	// Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec 
 	d = conv2d(date + 4);
 	switch (date[0]) {
-		case 'J': m = date[1] == 'a' ? 1 : m = date[2] == 'n' ? 6 : 7; break;
+		case 'J': m = date[1] == 'a' ? 1 : date[2] == 'n' ? 6 : 7; break;
 		case 'F': m = 2; break;
 		case 'A': m = date[2] == 'r' ? 4 : 8; break;
 		case 'M': m = date[2] == 'r' ? 3 : 5; break;
@@ -416,6 +416,7 @@ DateTime DS1307::now() {
 
 uint8_t DS3231::begin(void) {
   write(DS3231_CONTROL_ADDR, DS3231_INTC);
+  return 0;
 }
 
 uint8_t DS3231::read(const uint8_t addr) {

--- a/src/sensors/ir/IRremote.cpp
+++ b/src/sensors/ir/IRremote.cpp
@@ -188,13 +188,4 @@ ISR (TIMER_INTR_NAME)
 			irparams.rcvstate = STATE_STOP;
 		 	break;
 	}
-
-	// If requested, flash LED while receiving IR data
-	if (irparams.blinkflag) {
-		if (irdata == MARK)
-			if (irparams.blinkpin) digitalWrite(irparams.blinkpin, HIGH); // Turn user defined pin LED on
-				else BLINKLED_ON() ;   // if no user defined LED pin, turn default LED pin for the hardware on
-		else if (irparams.blinkpin) digitalWrite(irparams.blinkpin, LOW); // Turn user defined pin LED on
-				else BLINKLED_OFF() ;   // if no user defined LED pin, turn default LED pin for the hardware on
-	}
 }

--- a/src/sensors/tca8418.cpp
+++ b/src/sensors/tca8418.cpp
@@ -78,6 +78,8 @@ bool KEYS::configureKeys(uint8_t rows, uint16_t cols, uint8_t config)
 
   config |= CFG_AI;
   writeByte(config, REG_CFG);
+
+  return true;
 }
 
 void KEYS::writeByte(uint8_t data, uint8_t reg) {

--- a/src/web/WebSocketsClient.cpp
+++ b/src/web/WebSocketsClient.cpp
@@ -327,6 +327,10 @@ void WebSocketsClient::messageReceived(WSclient_t * client, WSopcode_t opcode, u
 		case WSop_continuation:
 			type = fin ? WStype_FRAGMENT_FIN : WStype_FRAGMENT;
 			break;
+        case WSop_close:
+        case WSop_ping:
+        case WSop_pong:
+            break;
     }
 
     runCbEvent(type, payload, length);

--- a/src/web/WebSocketsServer.cpp
+++ b/src/web/WebSocketsServer.cpp
@@ -490,6 +490,10 @@ void WebSocketsServer::messageReceived(WSclient_t * client, WSopcode_t opcode, u
         case WSop_continuation:
             type = fin ? WStype_FRAGMENT_FIN : WStype_FRAGMENT;
             break;
+        case WSop_close:
+        case WSop_ping:
+        case WSop_pong:
+            break;
     }
 
     runCbEvent(client->num, type, payload, length);


### PR DESCRIPTION
This PR includes the modifications I found necessary to make in order to allow this component to compile with ESP-IDF 3.2 and while using the arduino-esp32 component.

https://github.com/OtherCrashOverride/esp-idf/tree/release/v3.2-odroid
https://github.com/espressif/arduino-esp32