### PR TITLE
some bugs fix to support ESP-IDF environment

### DIFF
--- a/component.mk
+++ b/component.mk
@@ -5,5 +5,5 @@
 
 #COMPONENT_SRCDIRS := . src
 #COMPONENT_ADD_INCLUDEDIRS := . src
-COMPONENT_SRCDIRS := src
-COMPONENT_ADD_INCLUDEDIRS := src
+COMPONENT_SRCDIRS := src src/Fonts src/sensors src/utility src/web
+COMPONENT_ADD_INCLUDEDIRS := src src/Fonts src/sensors src/utility src/web

--- a/src/sensors/RTClib.cpp
+++ b/src/sensors/RTClib.cpp
@@ -153,7 +153,7 @@ DateTime::DateTime (const char* date, const char* time) {
 	// Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec 
 	d = conv2d(date + 4);
 	switch (date[0]) {
-		case 'J': m = date[1] == 'a' ? 1 : m = date[2] == 'n' ? 6 : 7; break;
+		case 'J': m = date[1] == 'a' ? 1 : date[2] == 'n' ? 6 : 7; break;
 		case 'F': m = 2; break;
 		case 'A': m = date[2] == 'r' ? 4 : 8; break;
 		case 'M': m = date[2] == 'r' ? 3 : 5; break;
@@ -416,6 +416,7 @@ DateTime DS1307::now() {
 
 uint8_t DS3231::begin(void) {
   write(DS3231_CONTROL_ADDR, DS3231_INTC);
+  return 0;
 }
 
 uint8_t DS3231::read(const uint8_t addr) {

--- a/src/sensors/tca8418.cpp
+++ b/src/sensors/tca8418.cpp
@@ -78,6 +78,7 @@ bool KEYS::configureKeys(uint8_t rows, uint16_t cols, uint8_t config)
 
   config |= CFG_AI;
   writeByte(config, REG_CFG);
+  return true;
 }
 
 void KEYS::writeByte(uint8_t data, uint8_t reg) {

--- a/src/utility/battery.cpp
+++ b/src/utility/battery.cpp
@@ -5,6 +5,7 @@
  *      Author: mdrjr
  */
 
+#include <esp_sleep.h>
 #include "battery.h"
 
 Battery::Battery() {

--- a/src/web/WebSockets.cpp
+++ b/src/web/WebSockets.cpp
@@ -39,7 +39,7 @@ extern "C" {
 #ifdef ESP8266
 #include <Hash.h>
 #elif defined(ESP32)
-#include <hwcrypto/sha.h>
+#include <esp32/sha.h>
 #else
 
 extern "C" {

--- a/src/web/WebSocketsClient.cpp
+++ b/src/web/WebSocketsClient.cpp
@@ -324,9 +324,11 @@ void WebSocketsClient::messageReceived(WSclient_t * client, WSopcode_t opcode, u
         case WSop_binary:
             type = fin ? WStype_BIN : WStype_FRAGMENT_BIN_START;
             break;
-		case WSop_continuation:
-			type = fin ? WStype_FRAGMENT_FIN : WStype_FRAGMENT;
-			break;
+        case WSop_continuation:
+            type = fin ? WStype_FRAGMENT_FIN : WStype_FRAGMENT;
+            break;
+	default:
+	    break;
     }
 
     runCbEvent(type, payload, length);

--- a/src/web/WebSocketsServer.cpp
+++ b/src/web/WebSocketsServer.cpp
@@ -490,6 +490,8 @@ void WebSocketsServer::messageReceived(WSclient_t * client, WSopcode_t opcode, u
         case WSop_continuation:
             type = fin ? WStype_FRAGMENT_FIN : WStype_FRAGMENT;
             break;
+	default:
+	    break;
     }
 
     runCbEvent(client->num, type, payload, length);


### PR DESCRIPTION
Unfortunately, ODROID-GO library doesn’t support ESP-IDF (Espressif IoT Development Framework).
This PL is intended to remedy this problem.
The detailed explanation is presented in [this link](https://medium.com/@jungpil.yu/esp-idf-based-development-environment-for-odroid-go-e27ff41b4adf).
