### PR TITLE
fix compiler warnings

### DIFF
--- a/src/sensors/Rtc_Pcf8563.cpp
+++ b/src/sensors/Rtc_Pcf8563.cpp
@@ -364,7 +364,7 @@ void Rtc_Pcf8563::getTime()
 }
 
 char *Rtc_Pcf8563::version(){
-  return RTCC_VERSION;  
+  return (char *)RTCC_VERSION;  
 }
 
 char *Rtc_Pcf8563::formatTime(byte style)

--- a/src/sensors/tca8418.cpp
+++ b/src/sensors/tca8418.cpp
@@ -291,7 +291,7 @@ void KEYS::pinInterruptMode(uint32_t pin, uint8_t mode, uint8_t level, uint8_t f
   read3Bytes((uint32_t *)&eventmodeSetting, REG_GPI_EM1);
 
   switch(mode) {
-    case INTERRUPT:
+    case K_INTERRUPT:
 	  bitSet(intSetting, pin);
 	  break;
 	case NOINTERRUPT:

--- a/src/sensors/tca8418.h
+++ b/src/sensors/tca8418.h
@@ -23,7 +23,7 @@
 #define GPIO 0x38
 #define EDGE 0x39
 #define LEVEL 0x40
-#define INTERRUPT 0x41
+#define K_INTERRUPT 0x41
 #define NOINTERRUPT 0x42
 #define FIFO 0x43
 #define NOFIFO 0x44


### PR DESCRIPTION
Fixed two compiler warnings caused by the sensor library:
- define symbol (INTERRUPT) conflict with ESP32 base
- type conversion warning for String to (char *) in a return statement